### PR TITLE
Added title for newsletter sub clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 + February: [This Month In Bitcoin Privacy, 18th Issue](https://enegnei.github.io/This-Month-In-Bitcoin-Privacy/February_2022/) (TMIBP18)
 + April: [This Month In Bitcoin Privacy, 19th Issue](https://enegnei.github.io/This-Month-In-Bitcoin-Privacy/April_2022/) (TMIBP19)
 
+## Subscribing to Newsletter
+
 At this time I'm not interested in creating a subscribe function through the honeypots known as email marketing services. Since several of them censor / block certain topics, including Bitcoin-related content, they wouldn't be very interested in me either anyway. Here are a few ways you can be notified about new editions:
 
 1. Follow me and / or this repository on GitHub. When a new edition comes out, I will link to it here in the readme. However, if you use this option, be aware that you may also be seeing all the changes I make throughout the month in your feed.


### PR DESCRIPTION
I think it'll be good to visually separate the gist about the Newsletter sub from the listing of the releases with a title, as that would help the overall readability of the README, especially for those just glancing through.

**P.S.** Happy to close this if you think it's too much of a nit.